### PR TITLE
[volumecache 02/12] Route volume loads through memory cache

### DIFF
--- a/agave_app/TimelineDockWidget.cpp
+++ b/agave_app/TimelineDockWidget.cpp
@@ -82,16 +82,10 @@ QTimelineWidget::OnTimeChanged(int newTime)
     LoadSpec loadSpec = m_loadSpec;
     loadSpec.time = newTime;
 
-    if (!m_reader) {
-      m_reader = std::shared_ptr<IFileReader>(FileReader::getReader(loadSpec.filepath, loadSpec.isImageSequence));
-      if (!m_reader) {
-        LOG_ERROR << "Could not find a reader for file " << loadSpec.filepath;
-        return;
-      }
-    }
-
     QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    std::shared_ptr<ImageXYZC> image = m_reader->loadFromFile(loadSpec);
+    // Reuse the reader created at file-open time so we skip re-opening the file
+    // and re-parsing metadata on every time-step.
+    std::shared_ptr<ImageXYZC> image = FileReader::loadAndCache(loadSpec, m_reader);
     QApplication::restoreOverrideCursor();
     if (!image) {
       // TODO FIXME if we fail to set the new time, then reset the GUI to previous time

--- a/agave_app/agaveGui.cpp
+++ b/agave_app/agaveGui.cpp
@@ -828,7 +828,7 @@ agaveGui::open(const std::string& file, const Serialize::ViewerState* vs, bool i
   // We can update the render and gui progressively as chunks are loaded.
   // Also, this would allow renders to be cancelled during loading.
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  std::shared_ptr<ImageXYZC> image = reader->loadFromFile(loadSpec);
+  std::shared_ptr<ImageXYZC> image = FileReader::loadAndCache(loadSpec, reader);
   QApplication::restoreOverrideCursor();
   if (!image) {
     LOG_DEBUG << "Failed to open " << file;

--- a/renderlib/command.cpp
+++ b/renderlib/command.cpp
@@ -571,14 +571,7 @@ SetTimeCommand::execute(ExecutionContext* c)
   std::shared_ptr<ImageXYZC> image;
   try {
 
-    std::unique_ptr<IFileReader> reader(FileReader::getReader(loadSpec.filepath, loadSpec.isImageSequence));
-    if (!reader) {
-      LOG_ERROR << "Could not find a reader for file " << loadSpec.filepath;
-      image = nullptr;
-      return;
-    }
-
-    image = reader->loadFromFile(loadSpec);
+    image = FileReader::loadAndCache(loadSpec);
   } catch (...) {
     LOG_ERROR << "Failed to load time " << m_data.m_time << " from file " << c->m_loadSpec.toString();
     image = nullptr;
@@ -670,7 +663,7 @@ LoadDataCommand::execute(ExecutionContext* c)
   c->m_loadSpec.maxz = m_data.m_zmax;
 
   // TODO can we load time sequences of separate files here?
-  std::unique_ptr<IFileReader> reader(FileReader::getReader(m_data.m_path));
+  std::shared_ptr<IFileReader> reader(FileReader::getReader(m_data.m_path));
   if (!reader) {
     LOG_ERROR << "Could not find a reader for file " << m_data.m_path;
     return;
@@ -678,7 +671,7 @@ LoadDataCommand::execute(ExecutionContext* c)
 
   VolumeDimensions dims = reader->loadDimensions(m_data.m_path, m_data.m_scene);
 
-  std::shared_ptr<ImageXYZC> image = reader->loadFromFile(c->m_loadSpec);
+  std::shared_ptr<ImageXYZC> image = FileReader::loadAndCache(c->m_loadSpec, reader);
   if (!image) {
     return;
   }

--- a/renderlib/io/FileReader.cpp
+++ b/renderlib/io/FileReader.cpp
@@ -7,12 +7,10 @@
 #include "FileReaderZarr.h"
 #include "ImageXYZC.h"
 #include "Logging.h"
+#include "CacheManager.h"
 
 #include <chrono>
 #include <filesystem>
-#include <map>
-
-std::map<std::string, std::shared_ptr<ImageXYZC>> FileReader::sPreloadedImageCache;
 
 // return file extension as lowercase
 std::string
@@ -66,30 +64,34 @@ FileReader::getReader(const std::string& filepath, bool isImageSequence)
 }
 
 std::shared_ptr<ImageXYZC>
-FileReader::loadAndCache(const LoadSpec& loadSpec)
+FileReader::loadAndCache(const LoadSpec& loadSpec, std::shared_ptr<IFileReader> reader)
 {
-  // check cache first of all.
-  auto cached = sPreloadedImageCache.find(loadSpec.filepath);
-  if (cached != sPreloadedImageCache.end()) {
-    return cached->second;
+  auto cached = CacheManager::instance().findImage(loadSpec);
+  if (cached) {
+    return cached;
   }
-
-  VolumeDimensions dims;
 
   std::shared_ptr<ImageXYZC> image;
 
-  std::string filepath = loadSpec.filepath;
+  const std::string& filepath = loadSpec.filepath;
 
-  std::unique_ptr<IFileReader> reader(FileReader::getReader(filepath));
+  // Fall back to constructing a new reader if the caller didn't supply one.
+  // A reused reader can skip re-opening the file and re-parsing metadata (notably
+  // valuable for time-series stepping on OME-Zarr/TIFF/CZI).
+  std::shared_ptr<IFileReader> ownedReader;
   if (!reader) {
-    LOG_ERROR << "Could not find a reader for file " << filepath;
-    return nullptr;
+    ownedReader.reset(FileReader::getReader(filepath, loadSpec.isImageSequence));
+    if (!ownedReader) {
+      LOG_ERROR << "Could not find a reader for file " << filepath;
+      return nullptr;
+    }
+    reader = ownedReader;
   }
 
   image = reader->loadFromFile(loadSpec);
 
   if (image) {
-    sPreloadedImageCache[filepath] = image;
+    CacheManager::instance().storeImage(loadSpec, image);
   }
 
   return image;
@@ -106,9 +108,11 @@ FileReader::loadFromArray_4D(uint8_t* dataArray,
                              bool addToCache)
 {
   // check cache first of all.
-  auto cached = sPreloadedImageCache.find(name);
-  if (cached != sPreloadedImageCache.end()) {
-    return cached->second;
+  LoadSpec cacheSpec;
+  cacheSpec.filepath = name;
+  auto cached = CacheManager::instance().findImage(cacheSpec);
+  if (cached) {
+    return cached;
   }
 
   // assume data is in CZYX order:
@@ -145,7 +149,9 @@ FileReader::loadFromArray_4D(uint8_t* dataArray,
 
   std::shared_ptr<ImageXYZC> sharedImage(im);
   if (addToCache) {
-    sPreloadedImageCache[name] = sharedImage;
+    LoadSpec newSpec;
+    newSpec.filepath = name;
+    CacheManager::instance().storeImage(newSpec, sharedImage);
   }
   return sharedImage;
 }

--- a/renderlib/io/FileReader.h
+++ b/renderlib/io/FileReader.h
@@ -2,7 +2,6 @@
 
 #include "IFileReader.h"
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -19,7 +18,11 @@ public:
 
   static IFileReader* getReader(const std::string& filepath, bool isImageSequence = false);
 
-  static std::shared_ptr<ImageXYZC> loadAndCache(const LoadSpec& loadSpec);
+  // If `reader` is provided, it is reused to load the image (skipping the cost of
+  // re-opening the file and re-parsing metadata). If null, a new reader is constructed
+  // via getReader(). The result is stored in the CacheManager on success either way.
+  static std::shared_ptr<ImageXYZC> loadAndCache(const LoadSpec& loadSpec,
+                                                 std::shared_ptr<IFileReader> reader = nullptr);
 
   static std::shared_ptr<ImageXYZC> loadFromArray_4D(uint8_t* dataArray,
                                                      std::vector<uint32_t> shape,
@@ -31,5 +34,4 @@ public:
                                                      bool addToCache = false);
 
 private:
-  static std::map<std::string, std::shared_ptr<ImageXYZC>> sPreloadedImageCache;
 };


### PR DESCRIPTION
Stacked draft PR 2 of 12 for image caching in AGAVE.

This PR wires volume loading call sites through the new memory cache and clears cached entries when the active load context changes.
