### PR TITLE
[volumecache 03/12] Initialize volume cache at fixed app cache root

### DIFF
--- a/agave_app/main.cpp
+++ b/agave_app/main.cpp
@@ -1,6 +1,7 @@
 #include "agaveGui.h"
 
 #include "mainwindow.h"
+#include "renderlib/CacheManager.h"
 #include "renderlib/Logging.h"
 #include "renderlib/io/FileReader.h"
 #include "renderlib/renderlib.h"
@@ -10,6 +11,7 @@
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QDir>
+#include <QStandardPaths>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -134,6 +136,22 @@ getUrlToOpen(const QUrl& agaveUrl)
   return "";
 }
 
+// Platform-appropriate cache directory for AGAVE's volume cache. Cache files
+// are not user data, so the location is fixed (not user-configurable) and
+// resolved once at startup, the same way the assets path is.
+std::string
+getCacheDirectory()
+{
+  QString baseDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+  if (baseDir.isEmpty()) {
+    baseDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+  }
+  if (baseDir.isEmpty()) {
+    baseDir = QDir::currentPath();
+  }
+  return QDir(baseDir).filePath("agave-cache").toStdString();
+}
+
 class AgaveApplication : public QApplication
 {
 public:
@@ -253,6 +271,12 @@ main(int argc, char* argv[])
       renderlib::cleanup();
       return 0;
     }
+
+    // Register the cache directory once for the lifetime of the process, after
+    // renderlib has successfully initialized. Resolving the platform path needs
+    // the Qt application name (set above). Applies to both server and GUI mode;
+    // caching stays inert until a CacheConfig enables it.
+    CacheManager::initialize(getCacheDirectory());
 
     if (isServer) {
       QString configPath = parser.value(serverConfigOption);

--- a/agave_app/main.cpp
+++ b/agave_app/main.cpp
@@ -273,9 +273,8 @@ main(int argc, char* argv[])
     }
 
     // Register the cache directory once for the lifetime of the process, after
-    // renderlib has successfully initialized. Resolving the platform path needs
-    // the Qt application name (set above). Applies to both server and GUI mode;
-    // caching stays inert until a CacheConfig enables it.
+    // renderlib has successfully initialized. 
+    // Note that caching stays inert until a CacheConfig enables it.
     CacheManager::initialize(getCacheDirectory());
 
     if (isServer) {

--- a/renderlib/CacheManager.cpp
+++ b/renderlib/CacheManager.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <filesystem>
 #include <functional>
+#include <fstream>
 #include <memory>
 #include <stdexcept>
 
@@ -142,6 +143,42 @@ CacheManager::CacheManager(std::string cacheDir)
 {
 }
 
+bool
+CacheManager::canWriteCacheDir(const std::string& path)
+{
+  if (path.empty()) {
+    return false;
+  }
+
+  std::error_code ec;
+  std::filesystem::path dir(path);
+  if (!std::filesystem::exists(dir, ec)) {
+    if (!std::filesystem::create_directories(dir, ec) || ec) {
+      LOG_WARNING << "canWriteCacheDir: failed to create " << path << ": " << ec.message();
+      return false;
+    }
+  } else if (!std::filesystem::is_directory(dir, ec) || ec) {
+    LOG_WARNING << "canWriteCacheDir: not a directory: " << path;
+    return false;
+  }
+
+  std::filesystem::path testPath = dir / ".agave_cache_write_test";
+  {
+    std::ofstream testFile(testPath, std::ios::binary | std::ios::trunc);
+    if (!testFile.is_open()) {
+      return false;
+    }
+    testFile << "test";
+    if (!testFile.good()) {
+      testFile.close();
+      std::filesystem::remove(testPath, ec);
+      return false;
+    }
+  }
+  std::filesystem::remove(testPath, ec);
+  return !ec;
+}
+
 void
 CacheManager::initialize(const std::string& cacheDir)
 {
@@ -150,7 +187,16 @@ CacheManager::initialize(const std::string& cacheDir)
                            "lifetime of the process.");
   }
 
-  singletonSlot() = std::make_unique<CacheManager>(cacheDir);
+  // Probe writability once, here, rather than on every config-apply: the cache
+  // root is fixed for the lifetime of the process. If the directory can't be
+  // created or written, leave the root unset so the disk tier stays inert
+  // regardless of what any later CacheConfig requests.
+  std::string root = cacheDir;
+  if (!root.empty() && !canWriteCacheDir(root)) {
+    LOG_WARNING << "Disk cache disabled: cache directory not writable: " << root;
+    root.clear();
+  }
+  singletonSlot() = std::make_unique<CacheManager>(root);
 }
 
 CacheManager&

--- a/renderlib/CacheManager.cpp
+++ b/renderlib/CacheManager.cpp
@@ -190,8 +190,7 @@ CacheManager::initialize(const std::string& cacheDir)
                            "lifetime of the process.");
   }
 
-  // Probe writability once, here, rather than on every config-apply: the cache
-  // root is fixed for the lifetime of the process. If the directory can't be
+  // The cache root is fixed for the lifetime of the process. If the directory can't be
   // created or written, leave the root unset so the disk tier stays inert
   // regardless of what any later CacheConfig requests.
   std::string root = cacheDir;

--- a/renderlib/CacheManager.cpp
+++ b/renderlib/CacheManager.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <filesystem>
 #include <functional>
+#include <fstream>
 #include <memory>
 #include <stdexcept>
 
@@ -145,6 +146,42 @@ CacheManager::CacheManager(std::string cacheDir)
 {
 }
 
+bool
+CacheManager::canWriteCacheDir(const std::string& path)
+{
+  if (path.empty()) {
+    return false;
+  }
+
+  std::error_code ec;
+  std::filesystem::path dir(path);
+  if (!std::filesystem::exists(dir, ec)) {
+    if (!std::filesystem::create_directories(dir, ec) || ec) {
+      LOG_WARNING << "canWriteCacheDir: failed to create " << path << ": " << ec.message();
+      return false;
+    }
+  } else if (!std::filesystem::is_directory(dir, ec) || ec) {
+    LOG_WARNING << "canWriteCacheDir: not a directory: " << path;
+    return false;
+  }
+
+  std::filesystem::path testPath = dir / ".agave_cache_write_test";
+  {
+    std::ofstream testFile(testPath, std::ios::binary | std::ios::trunc);
+    if (!testFile.is_open()) {
+      return false;
+    }
+    testFile << "test";
+    if (!testFile.good()) {
+      testFile.close();
+      std::filesystem::remove(testPath, ec);
+      return false;
+    }
+  }
+  std::filesystem::remove(testPath, ec);
+  return !ec;
+}
+
 void
 CacheManager::initialize(const std::string& cacheDir)
 {
@@ -153,7 +190,16 @@ CacheManager::initialize(const std::string& cacheDir)
                            "lifetime of the process.");
   }
 
-  singletonSlot() = std::make_unique<CacheManager>(cacheDir);
+  // Probe writability once, here, rather than on every config-apply: the cache
+  // root is fixed for the lifetime of the process. If the directory can't be
+  // created or written, leave the root unset so the disk tier stays inert
+  // regardless of what any later CacheConfig requests.
+  std::string root = cacheDir;
+  if (!root.empty() && !canWriteCacheDir(root)) {
+    LOG_WARNING << "Disk cache disabled: cache directory not writable: " << root;
+    root.clear();
+  }
+  singletonSlot() = std::make_unique<CacheManager>(root);
 }
 
 CacheManager&

--- a/renderlib/CacheManager.h
+++ b/renderlib/CacheManager.h
@@ -84,6 +84,12 @@ public:
   void resetStats();
 
 private:
+  // Verify that `path` is (or can be made) a writable directory. Creates the
+  // directory if it does not exist, then probes it by writing and deleting a
+  // small marker file. Returns false on any failure. Probed once, at
+  // initialize() time, since the cache root is fixed for the process lifetime.
+  static bool canWriteCacheDir(const std::string& path);
+
   CacheKey makeKey(const LoadSpec& loadSpec) const;
   std::uint64_t estimateImageBytes(const ImageXYZC& image) const;
   void touchEntry(std::list<CacheKey>::iterator it);


### PR DESCRIPTION
Stacked draft PR 3 of 12 for the volume cache work.

This PR resolves a platform cache directory once at app startup, injects it into renderlib, and makes sure it is a valid writeable directory.  If the directory is unavailable, caching will remain disabled.

