### PR TITLE
[volumecache 04/12] Guard disk cache clearing with marker file

### DIFF
--- a/renderlib/CacheManager.cpp
+++ b/renderlib/CacheManager.cpp
@@ -14,6 +14,12 @@
 
 namespace {
 
+// Marker file written into any directory we manage as our own disk cache root.
+// clearDiskCache requires this file to be present before it will delete
+// anything, which protects against the user pointing the cache dir at a path
+// like "C:\" or "/home/me" and then clicking "Clear disk cache".
+constexpr const char* kCacheMarkerFilename = ".agave-cache-dir";
+
 inline void
 hashCombine(std::size_t& seed, std::size_t value)
 {
@@ -227,7 +233,13 @@ CacheManager::setConfig(const CacheConfig& config)
     m_entries.clear();
     m_lruKeys.clear();
     m_currentRamBytes = 0;
+    m_diskEntries.clear();
+    m_currentDiskBytes = 0;
     return;
+  }
+  if (!m_config.enableDisk || m_cacheDir.empty()) {
+    m_diskEntries.clear();
+    m_currentDiskBytes = 0;
   }
   evictIfNeededLocked(0);
 }
@@ -285,6 +297,89 @@ CacheManager::clearMemoryCache()
   m_entries.clear();
   m_lruKeys.clear();
   m_currentRamBytes = 0;
+}
+
+void
+CacheManager::clearDiskCache()
+{
+  std::string cacheDir;
+  std::vector<std::string> knownEntryPaths;
+  {
+    std::scoped_lock lock(m_mutex);
+    cacheDir = m_cacheDir;
+
+    if (!isAgaveCacheDir(cacheDir)) {
+      LOG_WARNING << "Refusing to clear disk cache: directory missing AGAVE cache marker file (" << kCacheMarkerFilename
+                  << "): " << cacheDir;
+      return;
+    }
+
+    knownEntryPaths.reserve(m_diskEntries.size());
+    for (const auto& kv : m_diskEntries) {
+      knownEntryPaths.push_back(kv.second.path);
+    }
+    m_diskEntries.clear();
+    m_currentDiskBytes = 0;
+  }
+
+  if (cacheDir.empty()) {
+    return;
+  }
+
+  // Remove the per-entry subdirectories we know about.
+  for (const auto& path : knownEntryPaths) {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+  }
+
+  // Also remove any orphan per-entry subdirectories left behind by prior
+  // sessions or partial writes. We only touch subdirectories that contain a
+  // meta.json (i.e. look like cache entries we wrote) — anything else the user
+  // may have placed in the cache dir is preserved.
+  std::error_code dirEc;
+  for (auto it = std::filesystem::directory_iterator(cacheDir, dirEc);
+       it != std::filesystem::directory_iterator() && !dirEc;
+       it.increment(dirEc)) {
+    if (!it->is_directory()) {
+      continue;
+    }
+    std::filesystem::path metaPath = it->path() / "meta.json";
+    std::error_code existEc;
+    if (std::filesystem::exists(metaPath, existEc)) {
+      std::error_code rmEc;
+      std::filesystem::remove_all(it->path(), rmEc);
+    }
+  }
+}
+
+void
+CacheManager::writeCacheMarker(const std::string& path) const
+{
+  if (path.empty()) {
+    return;
+  }
+  std::error_code ec;
+  std::filesystem::create_directories(path, ec);
+  std::filesystem::path marker = std::filesystem::path(path) / kCacheMarkerFilename;
+  std::error_code existEc;
+  if (std::filesystem::exists(marker, existEc)) {
+    return;
+  }
+  std::ofstream out(marker.string(), std::ios::trunc);
+  if (out) {
+    out << "AGAVE disk cache root. Safe to delete this directory and its contents.\n";
+  }
+}
+
+bool
+CacheManager::isAgaveCacheDir(const std::string& path) const
+{
+  if (path.empty()) {
+    return false;
+  }
+  std::error_code ec;
+  std::filesystem::path marker = std::filesystem::path(path) / kCacheMarkerFilename;
+  return std::filesystem::exists(marker, ec);
 }
 
 CacheManager::CacheStats

--- a/renderlib/CacheManager.cpp
+++ b/renderlib/CacheManager.cpp
@@ -14,6 +14,12 @@
 
 namespace {
 
+// Marker file written into any directory we manage as our own disk cache root.
+// clearDiskCache requires this file to be present before it will delete
+// anything, which protects against the user pointing the cache dir at a path
+// like "C:\" or "/home/me" and then clicking "Clear disk cache".
+constexpr const char* kCacheMarkerFilename = ".agave-cache-dir";
+
 // The magic constant 0x9e3779b9 is 2^32 / golden_ratio, used to spread out the bits of the hash value.
 // This is a common technique for combining hash values of multiple fields into a single hash.
 // See also https://softwareengineering.stackexchange.com/a/402543
@@ -229,7 +235,13 @@ CacheManager::setConfig(const CacheConfig& config)
     m_entries.clear();
     m_lruKeys.clear();
     m_currentRamBytes = 0;
+    m_diskEntries.clear();
+    m_currentDiskBytes = 0;
     return;
+  }
+  if (!m_config.enableDisk || m_cacheDir.empty()) {
+    m_diskEntries.clear();
+    m_currentDiskBytes = 0;
   }
   evictIfNeededLocked(0);
 }
@@ -287,6 +299,89 @@ CacheManager::clearMemoryCache()
   m_entries.clear();
   m_lruKeys.clear();
   m_currentRamBytes = 0;
+}
+
+void
+CacheManager::clearDiskCache()
+{
+  std::string cacheDir;
+  std::vector<std::string> knownEntryPaths;
+  {
+    std::scoped_lock lock(m_mutex);
+    cacheDir = m_cacheDir;
+
+    if (!isAgaveCacheDir(cacheDir)) {
+      LOG_WARNING << "Refusing to clear disk cache: directory missing AGAVE cache marker file (" << kCacheMarkerFilename
+                  << "): " << cacheDir;
+      return;
+    }
+
+    knownEntryPaths.reserve(m_diskEntries.size());
+    for (const auto& kv : m_diskEntries) {
+      knownEntryPaths.push_back(kv.second.path);
+    }
+    m_diskEntries.clear();
+    m_currentDiskBytes = 0;
+  }
+
+  if (cacheDir.empty()) {
+    return;
+  }
+
+  // Remove the per-entry subdirectories we know about.
+  for (const auto& path : knownEntryPaths) {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+  }
+
+  // Also remove any orphan per-entry subdirectories left behind by prior
+  // sessions or partial writes. We only touch subdirectories that contain a
+  // meta.json (i.e. look like cache entries we wrote) — anything else the user
+  // may have placed in the cache dir is preserved.
+  std::error_code dirEc;
+  for (auto it = std::filesystem::directory_iterator(cacheDir, dirEc);
+       it != std::filesystem::directory_iterator() && !dirEc;
+       it.increment(dirEc)) {
+    if (!it->is_directory()) {
+      continue;
+    }
+    std::filesystem::path metaPath = it->path() / "meta.json";
+    std::error_code existEc;
+    if (std::filesystem::exists(metaPath, existEc)) {
+      std::error_code rmEc;
+      std::filesystem::remove_all(it->path(), rmEc);
+    }
+  }
+}
+
+void
+CacheManager::writeCacheMarker(const std::string& path) const
+{
+  if (path.empty()) {
+    return;
+  }
+  std::error_code ec;
+  std::filesystem::create_directories(path, ec);
+  std::filesystem::path marker = std::filesystem::path(path) / kCacheMarkerFilename;
+  std::error_code existEc;
+  if (std::filesystem::exists(marker, existEc)) {
+    return;
+  }
+  std::ofstream out(marker.string(), std::ios::trunc);
+  if (out) {
+    out << "AGAVE disk cache root. Safe to delete this directory and its contents.\n";
+  }
+}
+
+bool
+CacheManager::isAgaveCacheDir(const std::string& path) const
+{
+  if (path.empty()) {
+    return false;
+  }
+  std::error_code ec;
+  std::filesystem::path marker = std::filesystem::path(path) / kCacheMarkerFilename;
+  return std::filesystem::exists(marker, ec);
 }
 
 CacheManager::CacheStats

--- a/renderlib/CacheManager.h
+++ b/renderlib/CacheManager.h
@@ -78,7 +78,11 @@ public:
 
   std::shared_ptr<ImageXYZC> findImage(const LoadSpec& loadSpec);
   void storeImage(const LoadSpec& loadSpec, const std::shared_ptr<ImageXYZC>& image);
+  // Drop all entries from the in-memory cache. Disk cache is untouched.
   void clearMemoryCache();
+  // Drop all entries from the disk cache (refuses if the cache directory is
+  // missing the AGAVE marker file). Memory cache is untouched.
+  void clearDiskCache();
 
   CacheStats getStats() const;
   void resetStats();
@@ -96,6 +100,11 @@ private:
   // Precondition: caller must hold m_mutex.
   void evictIfNeededLocked(std::uint64_t incomingBytes);
   void storeImageInMemory(const CacheKey& key, const std::shared_ptr<ImageXYZC>& image);
+  // Writes a marker file to a directory we manage as our own disk cache root.
+  // clearDiskCache refuses to delete anything unless this marker is present,
+  // protecting against accidental wipes of user-typed paths (e.g. "C:\").
+  void writeCacheMarker(const std::string& path) const;
+  bool isAgaveCacheDir(const std::string& path) const;
 
   mutable std::mutex m_mutex;
   CacheConfig m_config;
@@ -113,5 +122,15 @@ private:
   };
 
   std::unordered_map<CacheKey, CacheEntry, CacheKeyHash> m_entries;
+
+  struct DiskEntry
+  {
+    std::string path;
+    std::uint64_t bytes = 0;
+    std::uint64_t lastAccess = 0;
+  };
+
+  std::unordered_map<std::string, DiskEntry> m_diskEntries;
+  std::uint64_t m_currentDiskBytes = 0;
   CacheStats m_stats;
 };


### PR DESCRIPTION
Stacked draft PR 4 of 12 for the refreshed volume cache work.

This adds global cache clearing functionality.  It also deposits and checks against special marker files to try to be safe about only deleting info that was cached by agave. 